### PR TITLE
♻️ Remove aria-label on current slide

### DIFF
--- a/src/slider.js
+++ b/src/slider.js
@@ -195,7 +195,7 @@ export default class Slider extends React.Component {
         <li
           key={i}
           role="tabpanel"
-          aria-label={`${settings.accessibilitySlideLabel}-${i + 1}`}
+          aria-label={settings.accessibilitySlideLabel && `${settings.accessibilitySlideLabel}-${i + 1}`}
           style={settings.variableWidth ? { width: currentWidth } : null}
         >
           {newSlide}


### PR DESCRIPTION
PR pour enlever l'aria-label du current slide afin qu'il n'override pas les aria-labels de l'enfant.

Pour tester, ajouter la prop accessibilitySlideLabel au settings du SimpleSlider présent dans les exemples du repo.